### PR TITLE
Fix css watch paths to allow reloading

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,8 +195,8 @@ gulp.task('serve', ['styles', 'elements', 'images'], function () {
   });
 
   gulp.watch(['app/**/*.html'], reload);
-  gulp.watch(['app/styles/**/*.{css}'], ['styles', reload]);
-  gulp.watch(['app/elements/**/*.{css}'], ['elements', reload]);
+  gulp.watch(['app/styles/**/*.css'], ['styles', reload]);
+  gulp.watch(['app/elements/**/*.css'], ['elements', reload]);
   gulp.watch(['app/{scripts,elements}/**/*.js'], ['jshint']);
   gulp.watch(['app/images/**/*'], reload);
 });


### PR DESCRIPTION
Change css file pattern on related watch tasks to allow reloading of files on change. Fixes #92
